### PR TITLE
Feature: define a custom user-class

### DIFF
--- a/packages/ipxe-bluebanquise/bluebanquise_dhcpretry.ipxe
+++ b/packages/ipxe-bluebanquise/bluebanquise_dhcpretry.ipxe
@@ -25,6 +25,8 @@ echo +----------------------------------------------------+
 echo | . . . . . . . BlueBanquise iPXE boot . . . . . . . |
 echo +----------------------------------------------------+
 
+set user-class BlueBanquise
+
 sleep 2
 
 :retry
@@ -44,6 +46,7 @@ echo | gateway:      ${net0.dhcp/gateway:ipv4}
 echo | dns-server:   ${net0.dhcp/dns:ipv4}
 echo | domain:       ${net0.dhcp/domain:string}
 echo | next-server:  ${net0.dhcp/next-server:ipv4}
+echo | user-class:   ${user-class:string}
 echo |
 echo +----------------------------------------------------+
 echo

--- a/packages/ipxe-bluebanquise/bluebanquise_standard.ipxe
+++ b/packages/ipxe-bluebanquise/bluebanquise_standard.ipxe
@@ -26,6 +26,8 @@ echo | . . . . . . . . . iPXE embed boot. . . . . . . . . |
 echo | . . . . . BlueBanquise - Benoit Leveugle . . . . . |
 echo +----------------------------------------------------+
 
+set user-class BlueBanquise
+
 sleep 4
 
 ifconf --configurator dhcp || shell
@@ -43,6 +45,7 @@ echo | gateway:      ${net0.dhcp/gateway:ipv4}
 echo | dns-server:   ${net0.dhcp/dns:ipv4}
 echo | domain:       ${net0.dhcp/domain:string}
 echo | next-server:  ${net0.dhcp/next-server:ipv4}
+echo | user-class:   ${user-class:string}
 echo |
 echo +----------------------------------------------------+
 echo


### PR DESCRIPTION
Identify this iPXE ROM as "BlueBanquise". It allows to discriminate this
ROM from other iPXE ROM that may not comply with BlueBanquise's PXE
chain. Comply with RFC 3004 (https://tools.ietf.org/html/rfc3004).

Note: RFC 3004 defines the DHCP user class as a set of length-value
tuples, but iPXE treats it as a string. You can choose to manually
construct a value which conforms to RFC 3004 using the set command. This
is a long-standing bug both in iPXE and in the reference DHCP server
implementation (ISC dhcpd). There is a substantial amount of
documentation which suggests checking option 77 for the value 'iPXE' to
identify iPXE clients, and using 'set user-class <text>' to specify a
custom user class. To avoid breaking existing setups, iPXE will continue
to provide option 77 as a plain string for DHCPv4.
(Source: http://ipxe.org/cfg/user-class)