### PR TITLE
packages: prometheus: Add modbus_exporter aka. prometheus-modbus-exporter

### DIFF
--- a/packages/prometheus/build.sh
+++ b/packages/prometheus/build.sh
@@ -54,7 +54,7 @@ unset package_native_architecture
 unset package_no_os_name
 cd $working_directory/build/prometheus
 
-# We only build KARMA for Ubuntu and Debian
+# We only build KARMA and modbus_exporter for Ubuntu and Debian
 if [ $distribution != "Ubuntu" ] && [ $distribution != "Debian" ]; then
 
   package_version=$prometheus_version
@@ -135,6 +135,22 @@ if [ $distribution != "Ubuntu" ] && [ $distribution != "Debian" ]; then
       mv *.deb /root/debbuild/DEBS/$distribution_architecture/
       cd $working_directory/build/prometheus
     fi
+  fi
+fi
+
+package_version=$modbus_exporter_version
+package_name=prometheus-modbus-exporter
+package_path_calc
+if [ ! -f $package_path ]; then
+  cp -a $root_directory/prometheus/modbus_exporter $working_directory/build/prometheus/modbus_exporter
+  mv modbus_exporter prometheus-modbus-exporter-$modbus_exporter_version
+  tar cvzf prometheus-modbus-exporter-$modbus_exporter_version.linux-$prometheus_arch.tar.gz prometheus-modbus-exporter-$modbus_exporter_version
+  rpmbuild -ta prometheus-modbus-exporter-$modbus_exporter_version.linux-$prometheus_arch.tar.gz --target=$distribution_architecture --define "_software_version $modbus_exporter_version" --define "_software_architecture $prometheus_arch"
+  if [ $distribution == "Ubuntu" ] || [ $distribution == "Debian" ]; then
+    cd /root
+    alien --to-deb --scripts /root/rpmbuild/RPMS/$distribution_architecture/prometheus-modbus-exporter-*
+    mv *.deb /root/debbuild/DEBS/$distribution_architecture/
+    cd $working_directory/build/prometheus
   fi
 fi
 

--- a/packages/prometheus/modbus_exporter/modbus_exporter.spec
+++ b/packages/prometheus/modbus_exporter/modbus_exporter.spec
@@ -1,33 +1,36 @@
-Name:           modbus_exporter
-Version:        0.4.1
-Release:        1
-Summary:        Prometheus exporter for Modbus RTU and TCP
-License:        MIT
-URL:            https://github.com/RichiH/modbus_exporter
+%define version %(echo "%{_software_version}" | sed -e 's/-/\./g')
 
-Source0:        https://github.com/RichiH/modbus_exporter/releases/download/v%{version}/%{name}-%{version}.linux-amd64.tar.gz
-Source1:        modbus_exporter.service
-Source2:	sysconfig_modbus_exporter
+Name:          prometheus-modbus-exporter
+Summary:       Prometheus exporter for Modbus RTU and TCP
+Version:       %{version}
+Release:       1%{?dist}
+License:       apache-2.0
+Group:         System Environment/Base
+Source0:       https://github.com/RichiH/modbus_exporter/releases/download/v%{_software_version}/%{name}-%{_software_version}.linux-%{_software_architecture}.tar.gz
+URL:           https://github.com/RichiH/modbus_exporter
+Packager:      Oxedions <oxedions@gmail.com>
 
-BuildRequires:  systemd
-%{?systemd_requires}
-Requires(pre):  shadow-utils
+BuildRequires: golang>=1.23.0
 
 %description
+modbus_exporter for the BlueBanquise stack
+
 The modbus_exporter is a Prometheus exporter that requests data from Modbus 
 devices (RTU and TCP) and exposes them for Prometheus scraping.
 
 %prep
-%setup -q -n %{name}
+mkdir -p %{builddir}
+git clone %{url}.git %{builddir}/%{name}
+cd %{builddir}/%{name}
+git checkout v%{_software_version}
 
 %build
+cd %{builddir}/%{name}
 go build -o modbus_exporter modbus_exporter.go
 
 %install
 #rm -rf %{buildroot}
-install -D -m 0755 modbus_exporter %{buildroot}/usr/bin/modbus_exporter
-install -D -m 0644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/modbus_exporter.service
-install -D -m 0644 %{SOURCE2} %{buildroot}/etc/sysconfig/modbus_exporter
+install -D -m 0755 %{builddir}/%{name}/modbus_exporter %{buildroot}/usr/bin/modbus_exporter
 
 %clean
 rm -rf %{buildroot}
@@ -35,16 +38,11 @@ rm -rf %{buildroot}
 %pre
 
 %post
-%systemd_post modbus_exporter.service
 
 %preun
-%systemd_preun modbus_exporter.service
 
 %postun
-%systemd_postun_with_restart modbus_exporter.service
 
 %files
 %defattr(-,root,root,-)
 /usr/bin/modbus_exporter
-/usr/lib/systemd/system/modbus_exporter.service
-%config(noreplace) /etc/sysconfig/modbus_exporter

--- a/packages/prometheus/modbus_exporter/modbus_exporter.spec
+++ b/packages/prometheus/modbus_exporter/modbus_exporter.spec
@@ -1,0 +1,50 @@
+Name:           modbus_exporter
+Version:        0.4.1
+Release:        1
+Summary:        Prometheus exporter for Modbus RTU and TCP
+License:        MIT
+URL:            https://github.com/RichiH/modbus_exporter
+
+Source0:        https://github.com/RichiH/modbus_exporter/releases/download/v%{version}/%{name}-%{version}.linux-amd64.tar.gz
+Source1:        modbus_exporter.service
+Source2:	sysconfig_modbus_exporter
+
+BuildRequires:  systemd
+%{?systemd_requires}
+Requires(pre):  shadow-utils
+
+%description
+The modbus_exporter is a Prometheus exporter that requests data from Modbus 
+devices (RTU and TCP) and exposes them for Prometheus scraping.
+
+%prep
+%setup -q -n %{name}
+
+%build
+go build -o modbus_exporter modbus_exporter.go
+
+%install
+#rm -rf %{buildroot}
+install -D -m 0755 modbus_exporter %{buildroot}/usr/bin/modbus_exporter
+install -D -m 0644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/modbus_exporter.service
+install -D -m 0644 %{SOURCE2} %{buildroot}/etc/sysconfig/modbus_exporter
+
+%clean
+rm -rf %{buildroot}
+
+%pre
+
+%post
+%systemd_post modbus_exporter.service
+
+%preun
+%systemd_preun modbus_exporter.service
+
+%postun
+%systemd_postun_with_restart modbus_exporter.service
+
+%files
+%defattr(-,root,root,-)
+/usr/bin/modbus_exporter
+/usr/lib/systemd/system/modbus_exporter.service
+%config(noreplace) /etc/sysconfig/modbus_exporter

--- a/packages/prometheus/modbus_exporter/modbus_exporter.spec
+++ b/packages/prometheus/modbus_exporter/modbus_exporter.spec
@@ -10,7 +10,7 @@ Source0:       https://github.com/RichiH/modbus_exporter/releases/download/v%{_s
 URL:           https://github.com/RichiH/modbus_exporter
 Packager:      Oxedions <oxedions@gmail.com>
 
-BuildRequires: golang>=1.23.0
+#BuildRequires: golang>=1.23.0
 
 %description
 modbus_exporter for the BlueBanquise stack

--- a/packages/prometheus/version.sh
+++ b/packages/prometheus/version.sh
@@ -5,3 +5,4 @@ ipmi_exporter_version=1.10.1
 node_exporter_version=1.10.2
 karma_version=0.122
 snmp_exporter_version=0.29.0
+modbus_exporter_version="v0.4.1-43-g05ffeb88"


### PR DESCRIPTION
Initial checkin to build and include an [exporter](https://github.com/RichiH/modbus_exporter) for [Modbus](https://www.modbus.org/) \([Wiki](https://en.wikipedia.org/wiki/Modbus)\) \(mostly infrastructure\) devices.